### PR TITLE
Feat/add android tap and pay

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,9 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation "com.stripe:stripeterminal:2.17.1"
+    implementation "com.stripe:stripeterminal:2.19.0"
+    implementation "com.stripe:stripeterminal-core:2.19.0"
+    implementation "com.stripe:stripeterminal-localmobile:2.19.0"
     implementation("com.squareup.moshi:moshi:1.14.0")
     implementation "com.google.code.gson:gson:2.8.8"
 }

--- a/android/src/main/java/io/event1/capacitorstripeterminal/StripeTerminal.java
+++ b/android/src/main/java/io/event1/capacitorstripeterminal/StripeTerminal.java
@@ -903,7 +903,8 @@ public class StripeTerminal
 
     SimulatorConfiguration newConfig = new SimulatorConfiguration(
       availableReaderUpdate,
-      simulatedCard
+      simulatedCard,
+      null
     );
 
     Terminal.getInstance().setSimulatorConfiguration(newConfig);


### PR DESCRIPTION
- Adds the StripeTerminal localmobile and core modules required for Android Tap-to-Pay
- Updates the stripe modules to latest version
- Fix SimulatedConfiguration object creation for constructor changes
- This has been tested and confirmed working in GetDuck private repo/codebases